### PR TITLE
in_ID Translation Update

### DIFF
--- a/client/resources/bundles/bundle_in_ID.properties
+++ b/client/resources/bundles/bundle_in_ID.properties
@@ -20,3 +20,14 @@ claj.manage.creating-room=Membuat ruangan...
 claj.manage.room-creation-failed=[scarlet]Gagal untuk merunding tautan ruangan![]\n\
                                  Peladen kemungkinan bukan dari peladen CLaJ atau versimu yang lawas.\n
 claj.manage.fetch-failed=Tidak dapat untuk mengambil dafter peladen publik.
+
+claj.message.server-closing=Peladen sedang ditutup, mohon menunggu untuk semenit atau buat yang lain.
+claj.message.packet-spamming=Pemain telah ditendang untuk melakukan spam paket.
+claj.message.already-hosting=Kamu sudah hosting sebuah ruangan! \nTidak dapat menhubung atau membuat yang lain.
+claj.message.room-closure-denied=[yellow]PERINGATAN:[] Seseorang menghubungkan melalui CLaJ mencoba untuk menutup ruangan tanpa izin.
+claj.message.con-closure-denied=[yellow]PERINGATAN:[] Seseorang menghubungkan melalui CLaJ mencoba untuk menendang pemain tanpa izin.
+
+claj.room.closed=Ruangan telah ditutup oleh peladen.
+claj.room.obsolete-client=Versi CLaJ-mu tidak kompatibel dengan peladen ini.
+claj.room.outdated-version=Versi CLaJ-mu belum diperbarui.\nDimohon untuk perbarui itu dengan memasangkan ulang mod 'claj'.
+claj.room.server-closed=Peladen telah ditutup, mohon menunggu untuk semenit atau pilih yang lain.

--- a/client/resources/bundles/bundle_in_ID.properties
+++ b/client/resources/bundles/bundle_in_ID.properties
@@ -1,4 +1,4 @@
-claj.join.name=Bergabung dengan CLaJ
+claj.join.name=Bergabung melalui CLaJ
 claj.join.link=Tautan:
 claj.join.invalid=[red]Tautan tidak sah:
 claj.join.valid=[lime]Tautan yang sah, kau bisa mencoba untuk menghubungkan

--- a/client/resources/bundles/bundle_in_ID.properties
+++ b/client/resources/bundles/bundle_in_ID.properties
@@ -1,4 +1,4 @@
-claj.join.name=Hubung dengan CLaJ
+claj.join.name=Bergabung dengan CLaJ
 claj.join.link=Tautan:
 claj.join.invalid=[red]Tautan tidak sah:
 claj.join.valid=[lime]Tautan yang sah, kau bisa mencoba untuk menghubungkan

--- a/client/resources/bundles/bundle_in_ID.properties
+++ b/client/resources/bundles/bundle_in_ID.properties
@@ -18,7 +18,7 @@ claj.manage.missing-port=[red]Port hilang
 claj.manage.invalid-port=[red]Port atau rentang port tidak sah
 claj.manage.creating-room=Membuat ruangan...
 claj.manage.room-creation-failed=[scarlet]Gagal untuk merunding tautan ruangan![]\n\
-                                 Peladen kemungkinan bukan dari peladen CLaJ atau versimu yang lawas.\n
+                                 Peladen kemungkinan bukan sebuah peladen CLaJ atau belum diperbarui.\n
 claj.manage.fetch-failed=Tidak dapat untuk mengambil dafter peladen publik.
 
 claj.message.server-closing=Peladen sedang ditutup, mohon menunggu untuk semenit atau buat yang lain.


### PR DESCRIPTION
due to #14, I am revising the translation and inserting the key. ~But, on `claj.manage.room-creation-failed` key was unchanged due to same context.~ done, it was changed

~This PR on Draft due to translation testing~