### PR TITLE
Remove old Mindustry France server

### DIFF
--- a/public-servers.hjson
+++ b/public-servers.hjson
@@ -5,5 +5,4 @@
 "Eradication UK": "uk1.eradication.fun:8025"
 "MDF Alps": "2.7.107.21:50000"
 "Mindustry France™ Official": "claj.jojofr.dev:34650"
-"Mindustry France™ Official (Old)": "claj.jojofr.dev:34651"
 "German bunny DE": "claj.l4p1n.ch:50000"


### PR DESCRIPTION
~~Pull request made in preparation of the removal of the old (CLaJ 2.3) Mindustry France server, planned in the next few days.~~

I noticed the usage going down and a whole lot of errors in this version, while seeing an increase in activity in the "new" (CLaJ 2.4) server.

~~Marked as a draft for now, will be marked "ready" once the server is down.~~

Ready to be merged, activity has been 0 for a few days. (People should update anyways since then)